### PR TITLE
[HU-9] Extracción de duracion de video en campo oculto

### DIFF
--- a/features/youtubeGeneral.feature
+++ b/features/youtubeGeneral.feature
@@ -1,23 +1,23 @@
 Feature: Validaciones funcionales en la plataforma de YouTube
   
   Background: navegar a la página de YouTube
-     Given abro la página de YouTube
+    Given abro la página de YouTube
 
-   @youtube
-     Scenario: Validar fecha de publicación reciente
-        Given realicé una búsqueda de videos
-        When abro los filtros de búsqueda
-        And selecciono el filtro Hoy
-        Then visualizo videos con fecha de publicación reciente
+  @youtube
+  Scenario: Validar fecha de publicación reciente
+    Given realizo una búsqueda con el texto "bbng" 
+    When abro los filtros de búsqueda
+    And selecciono el filtro Hoy
+    Then visualizo videos con fecha de publicación reciente
 
-    @busqueda
-    Scenario: Validación de una búsqueda en YouTube
-      Given Estoy en la página principal de YouTube
-      When Escribo Falling In Reverse y presiono Enter en la barra de búsqueda
-      Then Verifico que al menos un resultado contenga Falling In Reverse
-      And Verifico que el primer resultado muestre una miniatura visible
-      And Verifico que el primer resultado muestre un título visible
-      And Verifico que el primer resultado contenga una duración en formato mm:ss
+  @busqueda
+  Scenario: Validación de una búsqueda en YouTube
+    Given Estoy en la página principal de YouTube
+    When Escribo Falling In Reverse y presiono Enter en la barra de búsqueda
+    Then Verifico que al menos un resultado contenga Falling In Reverse
+    And Verifico que el primer resultado muestre una miniatura visible
+    And Verifico que el primer resultado muestre un título visible
+    And Verifico que el primer resultado contenga una duración en formato mm:ss
   
   @canal
   Scenario: Navegar al canal 
@@ -27,3 +27,12 @@ Feature: Validaciones funcionales en la plataforma de YouTube
     Then debería ver el nombre del canal
     And debería ver la pestaña de Videos
     And debería ver al menos un video con miniatura y título
+
+
+  @youtube
+  Scenario: Validación de duración de video en campo oculto 
+    Given realizo una búsqueda con el texto "lofi-music"
+    Then verifico que el primer resultado contiene un campo con la duración
+    And verifico que dicho campo está oculto
+    And verifico que la duración tiene un formato válido
+  

--- a/pages/searchPage.js
+++ b/pages/searchPage.js
@@ -1,0 +1,41 @@
+const { I } = inject();
+const { expect } = require("chai");
+
+class SearchPage {
+  constructor() {
+    this.fields = {
+      firstResultDuration:
+        '(//span[@class="style-scope ytd-thumbnail-overlay-time-status-renderer"])[1]',
+    };
+  }
+
+  async validateDurationSpan() {
+    await I.waitForElement(this.fields.firstResultDuration, 5);
+    console.log("Existe el campo de duración");
+  }
+
+  async validateHiddenDuration() {
+
+    const xpath = this.fields.firstResultDuration + "/.."
+    const parent = await locate(xpath);
+
+    const isHidden = await I.grabAttributeFrom(parent, "hidden");
+    expect(isHidden, "El campo duración no esta oculto").to.not.be.null;
+    console.log("El campo de duración está oculto");
+  }
+
+  async validateDurationFormat() {
+    
+    const durationText = await I.grabTextFrom(this.fields.firstResultDuration);
+    const durationPattern = /^(\d{1,3}:\d{2}(:\d{2})?)$/;
+
+    console.log("Texto de duración:", durationText.trim());
+    expect(
+      durationPattern.test(durationText.trim()),
+      "El formato de duración no es válido"
+    ).to.be.true;
+    console.log("El formato de duración es válido:");
+  }
+}
+
+module.exports = new SearchPage();

--- a/pages/youtubeMainPage.js
+++ b/pages/youtubeMainPage.js
@@ -17,12 +17,12 @@ class YoutubeMainPage {
         I.wait(2);
     }
 
-    async searchVideo(){
+    async searchVideo(title){
         await I.waitForElement(this.fields.searchBar, 5);
-        await I.fillField(this.fields.searchBar, "bbng");
+        await I.fillField(this.fields.searchBar, title);
         await I.pressKey("Enter");
         await I.wait(2);
-        console.log("Buscando video...");
+        console.log("Buscando frase:" + title);
     }
 
     async selectFilters(){

--- a/steps/validacionesYoutubeSteps.js
+++ b/steps/validacionesYoutubeSteps.js
@@ -2,6 +2,7 @@ const { I } = inject();
 const busquedaVideo = require("../pages/busquedaVideo.js");
 const verificarResultado = require("../pages/verificarResultado.js");
 const CanalPage = require("../pages/canalPage.js");
+const searchPage = require("../pages/searchPage.js");
 
 Given("Estoy en la página principal de YouTube", () => {
   //YoutubeHomePage.home
@@ -64,8 +65,8 @@ Given("abro la página de YouTube", async () => {
   await youtubeMainPage.goToHome();
 });
 
-Given("realicé una búsqueda de videos", async () => {
-  await youtubeMainPage.searchVideo();
+Given("realizo una búsqueda con el texto {string}", async (phrase) => {
+  await youtubeMainPage.searchVideo(phrase);
 });
 Then("abro los filtros de búsqueda", async () => {
   await youtubeMainPage.selectFilters();
@@ -76,4 +77,17 @@ Then("selecciono el filtro Hoy", async () => {
 
 Then("visualizo videos con fecha de publicación reciente", async () => {
   await youtubeMainPage.validarVideosRecientes();
+});
+
+
+Then("verifico que el primer resultado contiene un campo con la duración",
+  async () => {
+    await searchPage.validateDurationSpan();
+  }
+);
+Then("verifico que dicho campo está oculto", async () => {
+  await searchPage.validateHiddenDuration();
+});
+Then("verifico que la duración tiene un formato válido", async () => {
+  await searchPage.validateDurationFormat();
 });


### PR DESCRIPTION
In the **` validateDurationFormat() `** method in **`searchPage.js`**, it was suggested to use **`I.grabValueFrom`** to retrieve the duration value.
However, this method only works with **`<input>`**, **`<textarea>`**, or **`<select>`** elements, while the duration is rendered inside a **`<span>`** element.
For this reason, I opted to use **`I.grabTextFrom`**, which is more appropriate in this context.
Although **`I.grabAttributeFrom`** with the **`aria-label`** attribute could also work, **`I.grabTextFrom`** is simpler and avoids unnecessary complexity when validating the duration format.