### PR TITLE
Mocking Rick and Morty

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -16,6 +16,7 @@ exports.config = {
     I: "./steps_file.js", /** Crear al actor, quien va a realizar las acciones */
     karelPage: "./pages/karelPage.js", /** Creacion de la page Object */
     rickMortyMockPage: "./pages/rickMortyMockPage.js", /** Page Object para demo de Network Mocking */
+    rickMortyEpisodiosPage: "./pages/rickMortyEpisodiosPage.js",
   },
 
   gherkin: {
@@ -23,6 +24,7 @@ exports.config = {
     steps: [
       "./steps/karelSteps.js", /** Ubicaciones de los archivos que traducen Given,When y Then a javascript */
       "./steps/rickMortyMockSteps.js", /** Steps para demo de Network Mocking */
+      "./steps/rickMortyEpisodiosSteps.js",
     ],
   },
 

--- a/features/rickmorty-episodios.feature
+++ b/features/rickmorty-episodios.feature
@@ -1,0 +1,31 @@
+@rickmortyEpisodes
+Feature: Network Mocking de episodios de Rick and Morty
+
+@episodios @TC-A
+Scenario: Episodios mockeados reemplazan a los reales
+    Given el mock de episodios está activo con "Episodio Semillero Alpha" y "Episodio Semillero Beta"
+    When el usuario consulta la API de episodios
+    Then ve el episodio "Episodio Semillero Alpha" en la respuesta
+    And ve el episodio "Episodio Semillero Beta" en la respuesta
+    And no ve el episodio real "Pilot"
+
+@episodios @TC-B
+Scenario: API de episodios devuelve error 503
+    Given el mock de episodios devuelve un error 503
+    When el usuario consulta la API de episodios
+    Then la respuesta contiene el mensaje "Servicio de episodios no disponible"
+
+@episodios @TC-C
+Scenario: Modificar la respuesta real del primer episodio
+    Given el mock intercepta la respuesta real y renombra al primer episodio como "Episodio de Ricardo"
+    When el usuario consulta la API de episodios
+    Then ve el episodio "Episodio de Ricardo" en la respuesta
+
+@episodios @TC-D
+Scenario: Mock de un episodio específico por ID
+    Given el mock del episodio con ID 3 devuelve "Prueba de Automatización", fecha "Semilleros 2026" y código "S99E99"
+    When el usuario consulta el personaje con ID 3
+    When el usuario consulta el episodio con ID 3
+    Then ve el episodio "Prueba de Automatización" en la respuesta
+    And la respuesta contiene el mensaje "Semilleros 2026"
+    And la respuesta contiene el mensaje "S99E99"

--- a/features/rickmorty-episodios.feature
+++ b/features/rickmorty-episodios.feature
@@ -25,7 +25,7 @@ Scenario: Modificar la respuesta real del primer episodio
 Scenario: Mock de un episodio específico por ID
     Given el mock del episodio con ID 3 devuelve "Prueba de Automatización", fecha "Semilleros 2026" y código "S99E99"
     When el usuario consulta el personaje con ID 3
-    When el usuario consulta el episodio con ID 3
+    And el usuario consulta el episodio con ID 3
     Then ve el episodio "Prueba de Automatización" en la respuesta
     And la respuesta contiene el mensaje "Semilleros 2026"
     And la respuesta contiene el mensaje "S99E99"

--- a/pages/rickMortyEpisodiosPage.js
+++ b/pages/rickMortyEpisodiosPage.js
@@ -1,0 +1,164 @@
+const { I } = inject();
+
+class RickMortyEpisodiosPage {
+
+    urls = {
+        apiEpisodios: 'https://rickandmortyapi.com/api/episode',
+    };
+
+    // Métodos
+
+    mockEpisodios(nombre1, nombre2) {
+
+    I.usePlaywrightTo('mockear lista de episodios', async ({ page }) => {
+
+        await page.route('**/api/episode', route => {
+
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+
+                body: JSON.stringify({
+                    info: {
+                        count: 2,
+                        pages: 1,
+                        next: null,
+                        prev: null,
+                    },
+
+                    results: [
+                        {
+                            id: 1000,
+                            name: nombre1,
+                            air_date: 'Semilleros 2026',
+                            episode: 'S99E01',
+                            characters: [],
+                            url: '',
+                            created: '2026-08-18',
+                        },
+                        {
+                            id: 1001,
+                            name: nombre2,
+                            air_date: 'Semilleros 2026',
+                            episode: 'S99E02',
+                            characters: [],
+                            url: '',
+                            created: '2026-08-18',
+                        },
+                    ],
+                }),
+            });
+        });
+    });
+    }
+
+    consultarAPIEpisodios() {
+        I.amOnPage(this.urls.apiEpisodios);
+    }
+
+    verEpisodio(nombre) {
+        I.see(nombre);
+    }
+
+    noVerEpisodio(nombre) {
+        I.dontSee(nombre);
+    }
+
+    mockError503(){
+    I.usePlaywrightTo('simular error 503 en episodios', async ({ page }) => {
+        await page.route('**/api/episode', route => {
+            route.fulfill({
+                status: 503,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    error: 'Servicio de episodios no disponible',
+                }),
+            });
+        });
+    });
+    }
+
+    verMensaje(texto){
+        I.see(texto);
+    }
+
+
+    mockModificarReal(nuevoNombre) {
+    I.usePlaywrightTo(
+        'interceptar y modificar respuesta real',
+        async ({ page }) => {
+
+            await page.route(
+                '**/api/episode',
+                async route => {
+
+                    // 1. Obtener respuesta REAL
+                    const response = await route.fetch();
+
+                    // 2. Convertir respuesta a JSON
+                    const json = await response.json();
+
+                    // 3. Modificar el primer episodio
+                    if (json.results && json.results.length > 0) {
+                        json.results[0].name = nuevoNombre;
+                    }
+
+                    // 4. Enviar respuesta modificada
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify(json),
+                    });
+
+                }
+            );
+
+        }
+    );
+    }
+
+    mockEpisodioPorId(id, nombre, airDate, codigo) {
+
+    I.usePlaywrightTo(
+        `mockear episodio ID ${id}`,
+        async ({ page }) => {
+
+            await page.route(
+                `**/api/episode/${id}`,
+                route => {
+
+                    route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+
+                        body: JSON.stringify({
+                            id: id,
+                            name: nombre,
+                            air_date: airDate,
+                            episode: codigo,
+                            characters: [],
+                            url: `https://rickandmortyapi.com/api/episode/${id}`,
+                            created: '2026-08-18',
+                        }),
+                    });
+                }
+            );
+        }
+    );
+    }
+
+    consultarPersonajePorId(id) {
+    I.amOnPage(
+        `https://rickandmortyapi.com/api/character/${id}`
+    );
+    }
+
+    consultarEpisodioPorId(id) {
+    I.amOnPage(
+        `https://rickandmortyapi.com/api/episode/${id}`
+    );
+    }
+
+}
+
+module.exports = new RickMortyEpisodiosPage();

--- a/steps/rickMortyEpisodiosSteps.js
+++ b/steps/rickMortyEpisodiosSteps.js
@@ -1,20 +1,30 @@
 const { rickMortyEpisodiosPage } = inject();
 
-Given(/^el mock de episodios está activo con "(.+)" y "(.+)"$/,(nombre1, nombre2) => {rickMortyEpisodiosPage.mockEpisodios(nombre1,nombre2);});
+Given(/^el mock de episodios está activo con "(.+)" y "(.+)"$/,(nombre1, nombre2) => {
+    rickMortyEpisodiosPage.mockEpisodios(nombre1,nombre2);});
 
-When(/^el usuario consulta la API de episodios$/, () => {rickMortyEpisodiosPage.consultarAPIEpisodios();});
+When(/^el usuario consulta la API de episodios$/, () => {
+    rickMortyEpisodiosPage.consultarAPIEpisodios();});
 
-Then(/^ve el episodio "(.+)" en la respuesta$/, (nombre) => {rickMortyEpisodiosPage.verEpisodio(nombre);});
+Then(/^ve el episodio "(.+)" en la respuesta$/, (nombre) => {
+    rickMortyEpisodiosPage.verEpisodio(nombre);});
 
-Then(/^no ve el episodio real "(.+)"$/, (nombre) => {rickMortyEpisodiosPage.noVerEpisodio(nombre);});
+Then(/^no ve el episodio real "(.+)"$/, (nombre) => {
+    rickMortyEpisodiosPage.noVerEpisodio(nombre);});
 
-Given(/^el mock de episodios devuelve un error 503$/, () => {rickMortyEpisodiosPage.mockError503();});
+Given(/^el mock de episodios devuelve un error 503$/, () => {
+    rickMortyEpisodiosPage.mockError503();});
 
-Given(/^el mock intercepta la respuesta real y renombra al primer episodio como "(.+)"$/,(nuevoNombre) => {rickMortyEpisodiosPage.mockModificarReal(nuevoNombre);});
+Given(/^el mock intercepta la respuesta real y renombra al primer episodio como "(.+)"$/,(nuevoNombre) =>{
+    rickMortyEpisodiosPage.mockModificarReal(nuevoNombre);});
 
-Given(/^el mock del episodio con ID (\d+) devuelve "(.+)", fecha "(.+)" y código "(.+)"$/,(id, nombre, airDate, codigo) => {rickMortyEpisodiosPage.mockEpisodioPorId(parseInt(id),nombre,airDate,codigo);});
+Given(/^el mock del episodio con ID (\d+) devuelve "(.+)", fecha "(.+)" y código "(.+)"$/,(id, nombre, airDate, codigo) => {
+    rickMortyEpisodiosPage.mockEpisodioPorId(parseInt(id),nombre,airDate,codigo);});
 
-When(/^el usuario consulta el personaje con ID (\d+)$/, (id) => {rickMortyEpisodiosPage.consultarPersonajePorId(parseInt(id));});
+When(/^el usuario consulta el personaje con ID (\d+)$/, (id) => {
+    rickMortyEpisodiosPage.consultarPersonajePorId(parseInt(id));});
 
-When(/^el usuario consulta el episodio con ID (\d+)$/, (id) => {rickMortyEpisodiosPage.consultarEpisodioPorId(parseInt(id));});
+When(/^el usuario consulta el episodio con ID (\d+)$/, (id) => {
+    rickMortyEpisodiosPage.consultarEpisodioPorId(parseInt(id));
+});
 

--- a/steps/rickMortyEpisodiosSteps.js
+++ b/steps/rickMortyEpisodiosSteps.js
@@ -1,0 +1,20 @@
+const { rickMortyEpisodiosPage } = inject();
+
+Given(/^el mock de episodios está activo con "(.+)" y "(.+)"$/,(nombre1, nombre2) => {rickMortyEpisodiosPage.mockEpisodios(nombre1,nombre2);});
+
+When(/^el usuario consulta la API de episodios$/, () => {rickMortyEpisodiosPage.consultarAPIEpisodios();});
+
+Then(/^ve el episodio "(.+)" en la respuesta$/, (nombre) => {rickMortyEpisodiosPage.verEpisodio(nombre);});
+
+Then(/^no ve el episodio real "(.+)"$/, (nombre) => {rickMortyEpisodiosPage.noVerEpisodio(nombre);});
+
+Given(/^el mock de episodios devuelve un error 503$/, () => {rickMortyEpisodiosPage.mockError503();});
+
+Given(/^el mock intercepta la respuesta real y renombra al primer episodio como "(.+)"$/,(nuevoNombre) => {rickMortyEpisodiosPage.mockModificarReal(nuevoNombre);});
+
+Given(/^el mock del episodio con ID (\d+) devuelve "(.+)", fecha "(.+)" y código "(.+)"$/,(id, nombre, airDate, codigo) => {rickMortyEpisodiosPage.mockEpisodioPorId(parseInt(id),nombre,airDate,codigo);});
+
+When(/^el usuario consulta el personaje con ID (\d+)$/, (id) => {rickMortyEpisodiosPage.consultarPersonajePorId(parseInt(id));});
+
+When(/^el usuario consulta el episodio con ID (\d+)$/, (id) => {rickMortyEpisodiosPage.consultarEpisodioPorId(parseInt(id));});
+


### PR DESCRIPTION
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/d8924e63-c218-4002-906a-2b52753e5835" />

Reto 4 — Network Mocking episodios

Se realizó Network Mocking sobre la API de episodios de Rick and Morty

Escenarios:

TC-A: Intercepta `/api/episode` y reemplaza la respuesta real por dos episodios mockeados.
TC-B: Simula un error HTTP 503 con el mensaje `Servicio de episodios no disponible`.
TC-C: Intercepta la respuesta real mediante `route.fetch()`, modifica el nombre del primer episodio y reenvía la respuesta mediante `route.fulfill()`.
TC-D: Intercepta únicamente `/api/episode/3` y devuelve información mockeada, demostrando que `/api/character/3` continúa utilizando la respuesta real.