### PR TITLE
Reto 4 — Network Mocking episodios — Ximena Díaz

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -12,18 +12,20 @@ exports.config = {
     }
   },
 
-  include: {
-    I: "./steps_file.js", /** Crear al actor, quien va a realizar las acciones */
-    karelPage: "./pages/karelPage.js", /** Creacion de la page Object */
-    rickMortyMockPage: "./pages/rickMortyMockPage.js", /** Page Object para demo de Network Mocking */
-  },
+  include: { 
+  I: "./steps_file.js",
+  karelPage: "./pages/karelPage.js",
+  rickMortyMockPage: "./pages/rickMortyMockPage.js",
+  rickMortyEpisodiosPage: "./pages/rickMortyEpisodiosPage.js",
+},
 
   gherkin: {
     features: './features/*.feature', /** Ubicacion de los archivos features */
-    steps: [
-      "./steps/karelSteps.js", /** Ubicaciones de los archivos que traducen Given,When y Then a javascript */
-      "./steps/rickMortyMockSteps.js", /** Steps para demo de Network Mocking */
-    ],
+    steps: [ 
+  "./steps/karelSteps.js",
+  "./steps/rickMortyMockSteps.js",
+  "./steps/rickMortyEpisodiosSteps.js",
+],
   },
 
   plugins: { /**Son las funcionalidades extra */

--- a/features/rickmorty-episodios.feature
+++ b/features/rickmorty-episodios.feature
@@ -1,0 +1,48 @@
+@episodios
+
+Feature: Network Mocking de episodios de Rick and Morty API
+
+  Como tester
+  Quiero interceptar y controlar las respuestas de la API de episodios
+  Para probar diferentes escenarios sin depender del servidor real
+
+
+  @episodios-mock
+
+  Scenario: Los episodios mockeados reemplazan a los episodios reales
+
+    Given el mock de episodios está activo con "Episodio Semillero Alpha" y "Episodio Semillero Beta"
+    When el usuario consulta la API de episodios
+    Then ve el episodio "Episodio Semillero Alpha" en la respuesta
+    And ve el episodio "Episodio Semillero Beta" en la respuesta
+    And no ve el episodio real "Pilot"
+
+
+  @episodios-error
+
+  Scenario: La API de episodios simula un error 503
+
+    Given el mock de episodios devuelve un error 503
+    When el usuario consulta la API de episodios
+    Then la respuesta contiene el mensaje "Servicio de episodios no disponible"
+
+
+  @episodios-modificar
+
+  Scenario: La respuesta real es interceptada y el primer episodio es renombrado
+
+    Given el mock intercepta la respuesta real y renombra al primer episodio como "Episodio de Ximena"
+    When el usuario consulta la API de episodios
+    Then ve el episodio "Episodio de Ximena" en la respuesta
+
+
+  @episodio-id
+
+  Scenario: El episodio con ID 3 es reemplazado por uno personalizado
+
+    Given el mock del episodio con ID 3 devuelve "Prueba de Automatización" con fecha "Semilleros 2026" y código "S99E99"
+    When el usuario consulta el personaje con ID 3
+    And el usuario consulta el episodio con ID 3
+    Then ve el nombre "Prueba de Automatización" en la respuesta
+    And ve la fecha "Semilleros 2026" en la respuesta
+    And ve el código de episodio "S99E99" en la respuesta

--- a/pages/rickMortyEpisodiosPage.js
+++ b/pages/rickMortyEpisodiosPage.js
@@ -1,0 +1,147 @@
+const { I } = inject();
+
+class RickMortyEpisodiosPage {
+
+    urls = {
+        apiEpisodios: 'https://rickandmortyapi.com/api/episode',
+        apiEpisodio3: 'https://rickandmortyapi.com/api/episode/3',
+        apiPersonaje3: 'https://rickandmortyapi.com/api/character/3',
+    };
+
+    // ESCENARIO A
+    // Mock completo de la lista de episodios
+    mockEpisodios(nombre1, nombre2) {
+        I.usePlaywrightTo('mockear lista de episodios', async ({ page }) => {
+            await page.route('**/api/episode', route => {
+                route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        info: {
+                            count: 2,
+                            pages: 1,
+                            next: null,
+                            prev: null,
+                        },
+                        results: [
+                            {
+                                id: 1000,
+                                name: nombre1,
+                                air_date: 'Semilleros 2026',
+                                episode: 'S99E01',
+                                characters: [],
+                                url: '',
+                                created: '2026-08-19',
+                            },
+                            {
+                                id: 1001,
+                                name: nombre2,
+                                air_date: 'Semilleros 2026',
+                                episode: 'S99E02',
+                                characters: [],
+                                url: '',
+                                created: '2026-08-19',
+                            },
+                        ],
+                    }),
+                });
+            });
+        });
+    }
+
+    // ESCENARIO B
+    // Mock de error 503
+    mockError503() {
+        I.usePlaywrightTo('simular error 503', async ({ page }) => {
+            await page.route('**/api/episode', route => {
+                route.fulfill({
+                    status: 503,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        error: 'Servicio de episodios no disponible',
+                        code: 503,
+                    }),
+                });
+            });
+        });
+    }
+
+    // ESCENARIO C
+    // Interceptar respuesta real y modificar el primer episodio
+    mockModificarReal(nuevoNombre) {
+        I.usePlaywrightTo('interceptar y modificar respuesta real', async ({ page }) => {
+            await page.route('**/api/episode', async route => {
+                const response = await route.fetch();
+                const json = await response.json();
+
+                if (json.results && json.results.length > 0) {
+                    json.results[0].name = nuevoNombre;
+                }
+
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify(json),
+                });
+            });
+        });
+    }
+
+    // ESCENARIO D
+    // Mock únicamente del episodio con ID 3
+    mockEpisodioPorId(id, nombre, fecha, codigo) {
+        I.usePlaywrightTo(`mockear episodio ID ${id}`, async ({ page }) => {
+            await page.route(`**/api/episode/${id}`, route => {
+                route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        id: id,
+                        name: nombre,
+                        air_date: fecha,
+                        episode: codigo,
+                        characters: [],
+                        url: `https://rickandmortyapi.com/api/episode/${id}`,
+                        created: '2026-08-19',
+                    }),
+                });
+            });
+        });
+    }
+
+    // NAVEGACIÓN
+    consultarAPIEpisodios() {
+        I.amOnPage(this.urls.apiEpisodios);
+    }
+
+    consultarPersonajePorId(id) {
+        I.amOnPage(this.urls.apiPersonaje3);
+    }
+
+    consultarEpisodioPorId(id) {
+        I.amOnPage(this.urls.apiEpisodio3);
+    }
+
+    // VERIFICACIONES
+    verEpisodio(nombre) {
+        I.see(nombre);
+    }
+
+    noVerEpisodio(nombre) {
+        I.dontSee(nombre);
+    }
+
+    verMensaje(texto) {
+        I.see(texto);
+    }
+
+    verFecha(fecha) {
+        I.see(fecha);
+    }
+
+    verCodigoEpisodio(codigo) {
+        I.see(codigo);
+    }
+}
+
+module.exports = new RickMortyEpisodiosPage();

--- a/pages/rickMortyMockPage.js
+++ b/pages/rickMortyMockPage.js
@@ -86,16 +86,22 @@ class RickMortyMockPage {
     }
 
     inyectarTitulo(nuevoTitulo) {
-        I.usePlaywrightTo('inyectar título en DOM', async ({ page }) => {
-            await page.evaluate((titulo) => {
-                // Cambia el título del tab del navegador
-                document.title = titulo;
-                // Cambia el H1 visible en la página
-                const h1 = document.querySelector('h1');
-                if (h1) h1.textContent = titulo;
-            }, nuevoTitulo);
-        });
-    }
+    I.usePlaywrightTo('inyectar título en DOM', async ({ page }) => {
+
+        await page.waitForLoadState('networkidle');
+        await page.waitForSelector('h1');
+
+        await page.evaluate((titulo) => {
+            document.title = titulo;
+
+            const h1 = document.querySelector('h1');
+            if (h1) {
+                h1.textContent = titulo;
+            }
+        }, nuevoTitulo);
+
+    });
+}
 
     // ─── EJEMPLO 4: Mock de personaje específico por ID ───────────────────────
     // Intercepta solo el endpoint de un personaje concreto: /api/character/1

--- a/steps/rickMortyEpisodiosSteps.js
+++ b/steps/rickMortyEpisodiosSteps.js
@@ -1,0 +1,58 @@
+const { rickMortyEpisodiosPage } = inject();
+
+// ESCENARIO A
+Given(/^el mock de episodios está activo con "(.+)" y "(.+)"$/, (nombre1, nombre2) => {
+    rickMortyEpisodiosPage.mockEpisodios(nombre1, nombre2);
+});
+
+When(/^el usuario consulta la API de episodios$/, () => {
+    rickMortyEpisodiosPage.consultarAPIEpisodios();
+});
+
+Then(/^ve el episodio "(.+)" en la respuesta$/, (nombre) => {
+    rickMortyEpisodiosPage.verEpisodio(nombre);
+});
+
+Then(/^no ve el episodio real "(.+)"$/, (nombre) => {
+    rickMortyEpisodiosPage.noVerEpisodio(nombre);
+});
+
+// ESCENARIO B
+Given(/^el mock de episodios devuelve un error 503$/, () => {
+    rickMortyEpisodiosPage.mockError503();
+});
+
+Then(/^la respuesta contiene el mensaje "(.+)"$/, (mensaje) => {
+    rickMortyEpisodiosPage.verMensaje(mensaje);
+});
+
+// ESCENARIO C
+Given(/^el mock intercepta la respuesta real y renombra al primer episodio como "(.+)"$/, (nuevoNombre) => {
+    rickMortyEpisodiosPage.mockModificarReal(nuevoNombre);
+});
+
+// ESCENARIO D
+Given(/^el mock del episodio con ID (\d+) devuelve "(.+)" con fecha "(.+)" y código "(.+)"$/, (id, nombre, fecha, codigo) => {
+    rickMortyEpisodiosPage.mockEpisodioPorId(
+        parseInt(id),
+        nombre,
+        fecha,
+        codigo
+    );
+});
+
+When(/^el usuario consulta el personaje con ID (\d+)$/, (id) => {
+    rickMortyEpisodiosPage.consultarPersonajePorId(parseInt(id));
+});
+
+When(/^el usuario consulta el episodio con ID (\d+)$/, (id) => {
+    rickMortyEpisodiosPage.consultarEpisodioPorId(parseInt(id));
+});
+
+Then(/^ve la fecha "(.+)" en la respuesta$/, (fecha) => {
+    rickMortyEpisodiosPage.verFecha(fecha);
+});
+
+Then(/^ve el código de episodio "(.+)" en la respuesta$/, (codigo) => {
+    rickMortyEpisodiosPage.verCodigoEpisodio(codigo);
+});

--- a/steps/rickMortyEpisodiosSteps.js
+++ b/steps/rickMortyEpisodiosSteps.js
@@ -1,4 +1,4 @@
-const { rickMortyEpisodiosPage } = inject();
+const { rickMortyEpisodiosPage, rickMortyMockPage } = inject();
 
 // ESCENARIO A
 Given(/^el mock de episodios está activo con "(.+)" y "(.+)"$/, (nombre1, nombre2) => {
@@ -39,10 +39,6 @@ Given(/^el mock del episodio con ID (\d+) devuelve "(.+)" con fecha "(.+)" y có
         fecha,
         codigo
     );
-});
-
-When(/^el usuario consulta el personaje con ID (\d+)$/, (id) => {
-    rickMortyEpisodiosPage.consultarPersonajePorId(parseInt(id));
 });
 
 When(/^el usuario consulta el episodio con ID (\d+)$/, (id) => {


### PR DESCRIPTION
## Reto 4 — Network Mocking con Rick and Morty

Se implementaron 4 escenarios para practicar Network Mocking utilizando Playwright y CodeceptJS sobre la API de episodios de Rick and Morty.

### Escenarios implementados

- Mock de episodios: se reemplazan los episodios reales por dos episodios personalizados.
- Error 503: se simula un error de servicio no disponible.
- Modificación de respuesta real: se intercepta la respuesta real y se modifica el nombre del primer episodio utilizando route.fetch() y route.fulfill().
- Mock por ID: se intercepta únicamente el episodio con ID 3 y se reemplazan sus datos por información personalizada.

### Evidencia

Los 4 escenarios fueron ejecutados correctamente y el reporte de Allure muestra 4/4 escenarios pasando, sin errores.
<img width="1366" height="768" alt="Captura de pantalla (35)" src="https://github.com/user-attachments/assets/4615e6f2-e970-45f9-a2b6-e33a42a11aa3" />
<img width="1366" height="768" alt="Captura de pantalla (34)" src="https://github.com/user-attachments/assets/ad3a216e-8042-4b6e-9ac5-f62dcd3ec960" />
