### PR TITLE
Reto 4: network mocking de episodios Rick and Morty

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -1,12 +1,12 @@
 /** @type {CodeceptJS.MainConfig} */
 exports.config = {
-  tests: './steps/*_steps.js', /** Indica donde se encuentran las pruebas a ejecutar */
+  tests: './steps/*Steps.js', /** Indica donde se encuentran las pruebas a ejecutar */
   output: './output', /** indica donde se guardaran los resultados de las pruebas*/
 
   helpers: { /** Ayudantes para realizar las acciones, configura el motor de automatizacion */
     Playwright: {
       browser: "chromium", /** Navegador que se va a utilizar */
-      url: 'https://www.telcel.com', /** Url de los casos a probar */
+      url: 'https://rickandmortyapi.com', /** Url de los casos a probar */
       show: !process.env.CI, /** En local muestra el navegador; en CI (GitHub Actions) corre headless */
       locale: "es-MX" /** Configuracion regional */
     }
@@ -16,6 +16,7 @@ exports.config = {
     I: "./steps_file.js", /** Crear al actor, quien va a realizar las acciones */
     karelPage: "./pages/karelPage.js", /** Creacion de la page Object */
     rickMortyMockPage: "./pages/rickMortyMockPage.js", /** Page Object para demo de Network Mocking */
+    rickMortyEpisodiosPage: "./pages/rickMortyEpisodiosPage.js"  /** Page Object para demo de Network Mocking de Reto4-Framework*/
   },
 
   gherkin: {
@@ -23,6 +24,7 @@ exports.config = {
     steps: [
       "./steps/karelSteps.js", /** Ubicaciones de los archivos que traducen Given,When y Then a javascript */
       "./steps/rickMortyMockSteps.js", /** Steps para demo de Network Mocking */
+      "./steps/rickMortyEpisodiosSteps.js", /** Steps para demo de Network Mocking de Reto4-Framework*/
     ],
   },
 

--- a/features/rickmorty-episodios.feature
+++ b/features/rickmorty-episodios.feature
@@ -1,0 +1,35 @@
+@episodios
+Feature: Simulacion de respuestas de la API de episodios de Rick and Morty
+  Como equipo de automatizacion
+  Quiero controlar las respuestas del servicio de episodios
+  Para validar escenarios que no puedo reproducir contra el servidor real
+
+  @RM001
+  Scenario: Los episodios simulados reemplazan a los episodios reales
+    Given el servicio de episodios devuelve los episodios "Episodio Semillero Alpha" y "Episodio Semillero Beta"
+    When el usuario consulta la lista de episodios
+    Then el usuario ve el texto "Episodio Semillero Alpha"
+    And el usuario ve el texto "Episodio Semillero Beta"
+    And el usuario no ve el texto "Pilot"
+
+  @RM002
+  Scenario: El servicio de episodios responde con un error de disponibilidad
+    Given el servicio de episodios falla con el mensaje "Servicio de episodios no disponible"
+    When el usuario consulta la lista de episodios
+    Then el usuario ve el texto "Servicio de episodios no disponible"
+
+  @RM003
+  Scenario: La respuesta real se modifica antes de llegar al usuario
+    Given el primer episodio real se renombra como "Episodio de Hector"
+    When el usuario consulta la lista de episodios
+    Then el usuario ve el texto "Episodio de Hector"
+
+  @RM004
+  Scenario: Solo el episodio con ID 3 es simulado
+    Given el episodio con ID 3 devuelve "Prueba de Automatizacion", "Semilleros 2026" y "S99E99"
+    When el usuario consulta el personaje con ID 3
+    Then el usuario no ve el texto "Prueba de Automatizacion"
+    When el usuario consulta el episodio con ID 3
+    Then el usuario ve el texto "Prueba de Automatizacion"
+    And el usuario ve el texto "Semilleros 2026"
+    And el usuario ve el texto "S99E99"

--- a/pages/rickMortyEpisodiosPage.js
+++ b/pages/rickMortyEpisodiosPage.js
@@ -1,0 +1,142 @@
+const { I } = inject();
+
+class RickMortyEpisodiosPage {
+
+    urls = {
+        apiEpisodios:  'https://rickandmortyapi.com/api/episode',
+        apiEpisodio3:  'https://rickandmortyapi.com/api/episode/3',
+        apiPersonaje3: 'https://rickandmortyapi.com/api/character/3',
+    };
+
+    // ─── ESCENARIO A: Mock de la lista completa de episodios ──────────────────
+    // Intercepta /api/episode y devuelve dos episodios inventados.
+    // El patron NO lleva /3 ni nada al final, asi captura solo la coleccion.
+    // El handler no necesita async: unicamente llama a fulfill, no espera nada.
+    mockEpisodios(nombre1, nombre2) {
+        I.usePlaywrightTo('mockear lista de episodios', async ({ page }) => {
+            await page.route('**/api/episode', route => {
+                route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        info: { count: 2, pages: 1, next: null, prev: null },
+                        results: [
+                            {
+                                id: 1000,
+                                name: nombre1,
+                                air_date: 'Semilleros 2026',
+                                episode: 'S01E01',
+                                characters: [],
+                                url: '',
+                                created: '2026-08-23',
+                            },
+                            {
+                                id: 1001,
+                                name: nombre2,
+                                air_date: 'Semilleros 2026',
+                                episode: 'S01E02',
+                                characters: [],
+                                url: '',
+                                created: '2026-08-23',
+                            },
+                        ],
+                    }),
+                });
+            });
+        });
+    }
+
+    // ─── ESCENARIO B: Mock de error 503 ───────────────────────────────────────
+    // El status 503 es lo que hace realista la simulacion de caida del servicio.
+    // Es un escenario imposible de reproducir contra un servidor que funciona bien.
+    mockError503(mensaje) {
+        I.usePlaywrightTo('simular error 503', async ({ page }) => {
+            await page.route('**/api/episode', route => {
+                route.fulfill({
+                    status: 503,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        error: mensaje,
+                        code: 503,
+                        detalle: 'Este error fue creado con un mock para pruebas',
+                    }),
+                });
+            });
+        });
+    }
+
+    // ─── ESCENARIO C: Interceptar respuesta REAL y modificarla ────────────────
+    // Llama al servidor REAL, recibe la respuesta, cambia un campo y la reenvia.
+    // Aqui el handler SI debe ser async, porque usa await dos veces adentro.
+    // Sin el async la funcion termina antes de resolver la promesa y el mock no se aplica.
+    mockModificarReal(nuevoNombre) {
+        I.usePlaywrightTo('interceptar y modificar respuesta real', async ({ page }) => {
+            await page.route('**/api/episode', async route => {
+                // 1. Deja pasar la peticion al servidor real y espera la respuesta
+                const response = await route.fetch();
+                const json     = await response.json();
+
+                // 2. Modifica solo el nombre del primer episodio
+                if (json.results && json.results.length > 0) {
+                    json.results[0].name = nuevoNombre;
+                }
+
+                // 3. Reenvia la respuesta modificada al navegador
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify(json),
+                });
+            });
+        });
+    }
+
+    // ─── ESCENARIO D: Mock de un episodio especifico por ID ───────────────────
+    // El patron es mas especifico, por eso /api/character/3 NO coincide
+    // y esa peticion llega al servidor real sin ser interceptada.
+    mockEpisodioPorId(id, nombre, fecha, codigo) {
+        I.usePlaywrightTo(`mockear episodio ID ${id}`, async ({ page }) => {
+            await page.route(`**/api/episode/${id}`, route => {
+                route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        id: id,
+                        name: nombre,
+                        air_date: fecha,
+                        episode: codigo,
+                        characters: [],
+                        url: `https://rickandmortyapi.com/api/episode/${id}`,
+                        created: '2026-08-23',
+                    }),
+                });
+            });
+        });
+    }
+
+    // ─── NAVEGACION ────────────────────────────────────────────────────────────
+    // El mock siempre se registra ANTES de navegar: si la peticion ya salio,
+    // no queda nada que interceptar.
+    consultarAPIEpisodios() {
+        I.amOnPage(this.urls.apiEpisodios);
+    }
+
+    consultarEpisodioPorId(id) {
+        I.amOnPage(`https://rickandmortyapi.com/api/episode/${id}`);
+    }
+
+    consultarPersonajePorId(id) {
+        I.amOnPage(`https://rickandmortyapi.com/api/character/${id}`);
+    }
+
+    // ─── VERIFICACIONES ────────────────────────────────────────────────────────
+    verTexto(texto) {
+        I.see(texto);
+    }
+
+    noVerTexto(texto) {
+        I.dontSee(texto);
+    }
+}
+
+module.exports = new RickMortyEpisodiosPage();

--- a/steps/rickMortyEpisodiosSteps.js
+++ b/steps/rickMortyEpisodiosSteps.js
@@ -1,0 +1,43 @@
+const { rickMortyEpisodiosPage } = inject();
+
+// GIVEN - se registran los mocks antes de cualquier navegacion ────────────────
+
+Given(/^el servicio de episodios devuelve los episodios "([^"]*)" y "([^"]*)"$/, (nombre1, nombre2) => {
+    rickMortyEpisodiosPage.mockEpisodios(nombre1, nombre2);
+});
+
+Given(/^el servicio de episodios falla con el mensaje "([^"]*)"$/, (mensaje) => {
+    rickMortyEpisodiosPage.mockError503(mensaje);
+});
+
+Given(/^el primer episodio real se renombra como "([^"]*)"$/, (nuevoNombre) => {
+    rickMortyEpisodiosPage.mockModificarReal(nuevoNombre);
+});
+
+Given(/^el episodio con ID 3 devuelve "([^"]*)", "([^"]*)" y "([^"]*)"$/, (nombre, fecha, codigo) => {
+    rickMortyEpisodiosPage.mockEpisodioPorId(3, nombre, fecha, codigo);
+});
+
+// WHEN - navegacion ───────────────────────────────────────────────────────────
+
+When(/^el usuario consulta la lista de episodios$/, () => {
+    rickMortyEpisodiosPage.consultarAPIEpisodios();
+});
+
+When(/^el usuario consulta el episodio con ID 3$/, () => {
+    rickMortyEpisodiosPage.consultarEpisodioPorId(3);
+});
+
+When(/^el usuario consulta el personaje con ID 3$/, () => {
+    rickMortyEpisodiosPage.consultarPersonajePorId(3);
+});
+
+// THEN - verificaciones parametrizadas, reutilizables por los cuatro escenarios ─
+
+Then(/^el usuario ve el texto "([^"]*)"$/, (texto) => {
+    rickMortyEpisodiosPage.verTexto(texto);
+});
+
+Then(/^el usuario no ve el texto "([^"]*)"$/, (texto) => {
+    rickMortyEpisodiosPage.noVerTexto(texto);
+});


### PR DESCRIPTION
<img width="1366" height="724" alt="image" src="https://github.com/user-attachments/assets/c9ef6d11-eddb-4443-b4a4-f837cc03eefa" />

Se implementaron 4 escenarios de network mocking sobre '/api/episode' usando 'page.route()'.

A, B y D fabrican la respuesta con 'fulfill()': dos episodios inventados, un error 503 y el episodio con ID 3. C funciona distinto: usa 'fetch()' para traer la respuesta real, modifica 'results[0].name' y la reenvía con 'fulfill()'.

D demuestra la especificidad del patrón: '/api/character/3' no coincide y llega al servidor real.

4/4 pasando en Allure (captura adjunta).